### PR TITLE
Fix parsing error of jle instruction

### DIFF
--- a/modules/assembler/utils/parsor.py
+++ b/modules/assembler/utils/parsor.py
@@ -2,7 +2,7 @@ import re
 
 from .opcodes import opcodes, registers
 
-opcodes_str = "|".join([s for s in opcodes.keys()])
+opcodes_str = "|".join(sorted(opcodes.keys(), key=len, reverse=True))
 registers_str = "|".join([s for s in registers.keys()])
 
 def parsor(asm):


### PR DESCRIPTION
```
Assembly: jle $100
{'label': None, 'opcode': 'jl', 'ra': None, 'rb': None, 'const': None, 'comment': None}
```

There was an error in parsing when using the `jle` instruction. By sorting the keys of `opcodes` in descending order by length in the regular expression, I ensured that longer instructions are matched first, thus resolving this issue.